### PR TITLE
Compatibility issue fix

### DIFF
--- a/napalm_dellos10/dellos10.py
+++ b/napalm_dellos10/dellos10.py
@@ -26,12 +26,12 @@ try:
 except ImportError:
     import xml.etree.ElementTree as ET
 
-import napalm.base.constants as C
-from napalm.base.base import NetworkDriver
-from napalm.base.exceptions import (
+import napalm_base.constants as C
+from napalm_base.base import NetworkDriver
+from napalm_base.exceptions import (
     CommandErrorException, ConnectionClosedException,
     MergeConfigException, ReplaceConfigException)
-from napalm.base.utils import py23_compat
+from napalm_base.utils import py23_compat
 
 from napalm_dellos10.utils.config_diff_util import NetworkConfig, dumps
 


### PR DESCRIPTION
Changed from napalm.base to napalm_base

Fixed issue:
>>> d = get_network_driver('dellos10')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.5/dist-packages/napalm_base/__init__.py", line 114, in get_network_driver
    .format(install_name=module_install_name))
napalm_base.exceptions.ModuleImportError: No class inheriting "napalm_base.base.NetworkDriver" found in "napalm_dellos10".