### PR TITLE
Fix command checking of echo in _gen_rollback_cfg

### DIFF
--- a/napalm_dellos10/dellos10.py
+++ b/napalm_dellos10/dellos10.py
@@ -477,7 +477,7 @@ class DellOS10Driver(NetworkDriver):
     def _gen_rollback_cfg(self):
         """Save a configuration that can be used for rollback."""
         cfg_file = self.rollback_cfg
-        cmd = 'copy running-config home://{}'.format(cfg_file)
+        cmd = 'copy running-configuration home://{}'.format(cfg_file)
         self.device.send_command_expect(cmd)
 
     def get_facts(self):


### PR DESCRIPTION
Fix generated pattern for command "copy running-config ..." in
_gen_rollback_cfg. The command has to be explicit in the full form
"copy running-configuration ..." to avoid breakage when the command
echo (which is full form in case of OS10 10.5.1.3) is compared with
the short form patern and fails the check.

The resulting exception was:
netmiko.ssh_exception.NetmikoTimeoutException: Timed-out reading
channel, data not available.

This fixes issue https://github.com/napalm-automation-community/napalm-dellos10/issues/24