### PR TITLE
Fix error handling in merge operations

### DIFF
--- a/napalm_dellos10/dellos10.py
+++ b/napalm_dellos10/dellos10.py
@@ -404,10 +404,10 @@ class DellOS10Driver(NetworkDriver):
                     "Merge source config file does not exist")
             cmd = 'copy home://{} running-configuration'.format(filename)
             output = self._commit_hostname_handler(cmd)
-            if 'Invalid input detected' in output:
-                self.rollback()
+            if 'Invalid input detected' in output or 'Error' in output:
                 err_header = "Configuration merge failed; automatic " \
-                             "rollback attempted"
+                             "rollback not available, leaving in an " \
+                             "inconsistent state"
                 merge_error = "{0}:\n{1}".format(err_header, output)
                 raise MergeConfigException(merge_error)
 


### PR DESCRIPTION
Merge operations can cause errors that are reported by various
messages containing string "Error".

The error handling program path must not call rollback() function
which is unimplemented and raises NotImplementedError exception
that is subsequently caught in Napalm code and fails to propagate
to the custom code or Napalm CLI. Therefore the cause of the merge
error and even the fact that the merge failed is lost.